### PR TITLE
predeployment zhushing

### DIFF
--- a/lib/sierra_record.rb
+++ b/lib/sierra_record.rb
@@ -31,13 +31,10 @@ class SierraBatch
     @retry_count.times { $kinesis_client.retry_failed_records }
     @process_statuses[:error] += $kinesis_client.failed_records.length
     @process_statuses[:success] += (@records.length - @process_statuses[:error])
-    #Decode and log ids of failed records
-    $kinesis_client.decode_failed_records
     unless $kinesis_client.failed_records.empty?
       ids = $kinesis_client.failed_records.map{ |record| record[:id] }.join(", ")
+      $logger.warn("#{$kinesis_client.failed_records.length} records failed to enter the kinesis stream, with ids: #{ids}")
     end
-
-    $logger.warn("#{$kinesis_client.failed_records.length} records failed to enter the kinesis stream, with ids: #{ids}")
   end
 
   class SierraRecord

--- a/spec/sierra_batch_spec.rb
+++ b/spec/sierra_batch_spec.rb
@@ -16,7 +16,6 @@ describe SierraBatch do
     $kinesis_client.stubs(:retry_failed_records)
     $kinesis_client.stubs(:failed_records).returns([])
     $kinesis_client.stubs(:<<)
-    $kinesis_client.stubs(:decode_failed_records)
   end
 
   describe "#encode_and_send_to_kinesis" do
@@ -67,19 +66,8 @@ describe SierraBatch do
       $kinesis_client.stubs(:retry_failed_records)
       $kinesis_client.stubs(:failed_records).returns([])
       $kinesis_client.stubs(:<<)
-      $kinesis_client.stubs(:decode_failed_records)
       $kinesis_client.stubs(:push_records).once
 
-      @test_batch.encode_and_send_to_kinesis
-    end
-
-    it "should decode failed_records before logging them" do
-      $kinesis_client = mock
-      $kinesis_client.stubs(:retry_failed_records)
-      $kinesis_client.stubs(:failed_records).returns([])
-      $kinesis_client.stubs(:<<)
-      $kinesis_client.stubs(:push_records)
-      $kinesis_client.stubs(:decode_failed_records).once
       @test_batch.encode_and_send_to_kinesis
     end
 


### PR DESCRIPTION
After deploying the most recent version of this app, Cloudwatch logs indicated that decode_failed_records was an undefined method being called from  nyplRubyUtil. Upon closer inspection, it looked like there was avro decoding of failed records happening within a custom-defined accessor method failed_records. I removed the call to decode_failed_records in the code and removed the test that was checking to see if it was called. I also noticed that as written, there was a logger warning about failed records that was not dependent on there actually being any failed records. I moved that code into a conditional checking for failed records. 