### PR TITLE
Fix git workflow (qa > development)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ jobs:
     - terraform -chdir=provisioning/production/item_delete init -input=false
     - echo "Deploying Item Delete to production"
     - terraform -chdir=provisioning/production/item_delete apply -auto-approve -input=false
-
 env:
   global:
   - TF_VERSION=1.0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [0.1.0] - 2022-04-01
+### Added
+- Environment variable for request_batch_size in order to integrate NYPLRubyUtils' #push_records batch processing
 ## [0.0.1] - 2020-09-16
 ### Added
 - Initial commit containing Sierra API poller, Avro encoding and Kinesis stream writing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This function polls the Sierra API for updates to the Bib, Holding and Item tabl
 
 ## Dependencies
 
-- nypl_ruby_util@0.0.2
+- nypl_ruby_util@0.1.0
 - aws-sdk-s3@1.74.0
 - rspec@3.9.0
 - mocha@1.11.2

--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,8 @@ def init
     schema_string: ENV["SCHEMA_TYPE"],
     stream_name: ENV["KINESIS_STREAM"],
     partition_key: "id",
-    batch_size: ENV["BATCH_SIZE"] || 25
+    # As of right now, we want to ensure that the sierra request batch size and the kinesis batch sizes are equal in order to avoid losing records in the case of a timeout.
+    batch_size: ENV["REQUEST_BATCH_SIZE"].to_i || 50
   })
 
   $logger.debug "Initialized function"

--- a/config/Bib-production.env
+++ b/config/Bib-production.env
@@ -13,3 +13,4 @@ RECORD_FIELDS=default,fixedFields,varFields,normTitle,normAuthor,orders,location
 SCHEMA_TYPE=BibPostRequest
 S3_KEY=BibPostRequest
 KINESIS_STREAM=BibPostRequest-production
+REQUEST_BATCH_SIZE=100

--- a/config/Bib-qa.env
+++ b/config/Bib-qa.env
@@ -13,3 +13,4 @@ RECORD_FIELDS=default,fixedFields,varFields,normTitle,normAuthor,orders,location
 SCHEMA_TYPE=BibPostRequest
 S3_KEY=BibPostRequest
 KINESIS_STREAM=BibPostRequest-qa
+REQUEST_BATCH_SIZE=100

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -72,10 +72,9 @@ class SierraManager
   # Fetches an individual record batch from Sierra
   def _fetch_record_batch
     # Set up the GET request params
-    update_date_str = "[#{@state.start_time},#{current_time}]"
     update_params = ENV['UPDATE_TYPE'] == 'delete' ? _delete_params : _update_params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-                   ["updatedDate", update_date_str], ["limit", @@request_batch_size]]
+                   update_params, ["limit", @@request_batch_size]]
 
     # Make query against Sierra API
     _query_sierra_api(param_array)

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -47,34 +47,20 @@ class SierraManager
   end
 
 
+  # Gets the current datetime and converts to date in case the app is configured for deletes
+  # Returns string representation of datetime/date
   def current_time
-    @current_time && @current_time.to_s
+    @current_time && @current_time.send(ENV['UPDATE_TYPE'] == 'delete' ? :to_date : :to_s).to_s
   end
 
   private
 
-  # generates the updatedDate param for updates
-  def _update_params
-    update_date_str = "[#{@state.start_time},#{current_time}]"
-    ["updatedDate", update_date_str]
-  end
-
-  # gets the current date from the current time
-  def _current_date
-    @current_time && @current_time.to_date.to_s
-  end
-
-  # generates the deletedDate param for deletes
-  def _delete_params
-     ["deletedDate", "[#{@state.start_time},#{_current_date}]"]
-  end
-
   # Fetches an individual record batch from Sierra
   def _fetch_record_batch
     # Set up the GET request params
-    update_params = ENV['UPDATE_TYPE'] == 'delete' ? _delete_params : _update_params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-                   update_params, ["limit", @@request_batch_size]]
+                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
+                   ["limit", @@request_batch_size]]
 
     # Make query against Sierra API
     _query_sierra_api(param_array)
@@ -126,7 +112,7 @@ class SierraManager
     # and we should set the state to start from this point and exit this invocation
     # else we should fetch and process the next batch
     if sierra_batch.size < @@request_batch_size
-      @state.set_current_state(ENV['UPDATE_TYPE'] == 'delete' ? _current_date : current_time, 0)
+      @state.set_current_state(current_time, 0)
       @processing = false
     else
       @state.set_current_state(@state.start_time, @state.start_offset + @@request_batch_size)

--- a/lib/state_manager.rb
+++ b/lib/state_manager.rb
@@ -19,7 +19,7 @@ class StateManager
   def fetch_current_state
     # Fetch JSON object from S3
     begin
-      status_uri = URI("#{ENV['NYPL_CORE_S3_BASE_URL']}/#{ENV['BUCKET_NAME']}/#{ENV['SCHEMA_TYPE'].downcase}_poller_status.json")
+      status_uri = URI("#{ENV['NYPL_CORE_S3_BASE_URL']}/#{ENV['BUCKET_NAME']}/#{ENV['S3_KEY'].downcase}_poller_status.json")
       $logger.debug "Fetching state from #{status_uri}"
       response = Net::HTTP.get_response(status_uri)
     rescue Exception => e

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -33,7 +33,7 @@ data "archive_file" "lambda_zip" {
 
 # Upload the zipped app to S3:
 resource "aws_s3_object" "uploaded_zip" {
-  bucket = "sierra-poller-state-${var.environment}"
+  bucket = "nypl-travis-builds-${var.environment}"
   key    = "Sierra${var.deployment_name}UpdatePoller-${var.environment}-dist.zip"
   acl    = "private"
   source = data.archive_file.lambda_zip.output_path
@@ -63,23 +63,3 @@ resource "aws_lambda_function" "poller_lambda" {
     variables = { for tuple in regexall("(.*?)=(.*)", file("../../config/${var.record_env}-${var.environment}.env")) : tuple[0] => tuple[1] }
   }
 }
-
-# resource "aws_cloudwatch_event_rule" "every_five_minutes" {
-#   name = "every-five-minutes"
-#   description = "Fires every five minutes"
-#   schedule_expression = "rate(5 minutes)"
-# }
-
-# resource "aws_cloudwatch_event_target" "run_poller_every_five_minutes" {
-#     rule = "${aws_cloudwatch_event_rule.every_five_minutes.name}"
-#     target_id = "Sierra${var.record_type}UpdatePoller-${var.environment}"
-#     arn = "${aws_lambda_function.poller_lambda.arn}"
-# }
-
-# resource "aws_lambda_permission" "allow_cloudwatch_to_call_pollers" {
-#     statement_id = "AllowExecutionFromCloudWatch"
-#     action = "lambda:InvokeFunction"
-#     function_name = "Sierra${var.record_type}UpdatePoller-${var.environment}"
-#     principal = "events.amazonaws.com"
-#     source_arn = "${aws_cloudwatch_event_rule.every_five_minutes.arn}"
-# }

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 variable "environment" {
-  type = string
-  default = "qa"
+  type        = string
+  default     = "qa"
   description = "The name of the environment (qa, production). This controls the name of the lambda and the env vars loaded."
 
   validation {
-    condition = contains(["qa", "production"], var.environment)
+    condition     = contains(["qa", "production"], var.environment)
     error_message = "The environment must be 'qa' or 'production'."
   }
 }
@@ -42,17 +42,18 @@ resource "aws_s3_object" "uploaded_zip" {
 
 # Create the lambda:
 resource "aws_lambda_function" "poller_lambda" {
-  description   = "A service for polling the Sierra API for updates from the Bibs endpoint"
-  function_name = "Sierra${var.deployment_name}UpdatePoller-${var.environment}"
-  handler       = "app.handle_event"
-  memory_size   = 128
-  role          = "arn:aws:iam::946183545209:role/lambda-full-access"
-  runtime       = "ruby2.7"
-  timeout       = 60
+  description                    = "A service for polling the Sierra API for updates from the Bibs endpoint"
+  function_name                  = "Sierra${var.record_type}UpdatePoller-${var.environment}"
+  handler                        = "app.handle_event"
+  memory_size                    = 128
+  role                           = "arn:aws:iam::946183545209:role/lambda-full-access"
+  runtime                        = "ruby2.7"
+  reserved_concurrent_executions = 1
+  timeout                        = 900
 
   # Location of the zipped code in S3:
-  s3_bucket     = aws_s3_object.uploaded_zip.bucket
-  s3_key        = aws_s3_object.uploaded_zip.key
+  s3_bucket = aws_s3_object.uploaded_zip.bucket
+  s3_key    = aws_s3_object.uploaded_zip.key
 
   # Trigger pulling code from S3 when the zip has changed:
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
@@ -63,22 +64,22 @@ resource "aws_lambda_function" "poller_lambda" {
   }
 }
 
-  # resource "aws_cloudwatch_event_rule" "every_five_minutes" {
-  #   name = "every-five-minutes"
-  #   description = "Fires every five minutes"
-  #   schedule_expression = "rate(5 minutes)"
-  # }
+# resource "aws_cloudwatch_event_rule" "every_five_minutes" {
+#   name = "every-five-minutes"
+#   description = "Fires every five minutes"
+#   schedule_expression = "rate(5 minutes)"
+# }
 
-  # resource "aws_cloudwatch_event_target" "run_poller_every_five_minutes" {
-  #     rule = "${aws_cloudwatch_event_rule.every_five_minutes.name}"
-  #     target_id = "Sierra${var.deployment_name}UpdatePoller-${var.environment}"
-  #     arn = "${aws_lambda_function.poller_lambda.arn}"
-  # }
+# resource "aws_cloudwatch_event_target" "run_poller_every_five_minutes" {
+#     rule = "${aws_cloudwatch_event_rule.every_five_minutes.name}"
+#     target_id = "Sierra${var.record_type}UpdatePoller-${var.environment}"
+#     arn = "${aws_lambda_function.poller_lambda.arn}"
+# }
 
-  # resource "aws_lambda_permission" "allow_cloudwatch_to_call_pollers" {
-  #     statement_id = "AllowExecutionFromCloudWatch"
-  #     action = "lambda:InvokeFunction"
-  #     function_name = "Sierra${var.deployment_name}UpdatePoller-${var.environment}"
-  #     principal = "events.amazonaws.com"
-  #     source_arn = "${aws_cloudwatch_event_rule.every_five_minutes.arn}"
-  # }
+# resource "aws_lambda_permission" "allow_cloudwatch_to_call_pollers" {
+#     statement_id = "AllowExecutionFromCloudWatch"
+#     action = "lambda:InvokeFunction"
+#     function_name = "Sierra${var.record_type}UpdatePoller-${var.environment}"
+#     principal = "events.amazonaws.com"
+#     source_arn = "${aws_cloudwatch_event_rule.every_five_minutes.arn}"
+# }

--- a/spec/sierra_batch_spec.rb
+++ b/spec/sierra_batch_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../lib/sierra_record"
+require_relative "../lib/sierra_batch"
 require_relative "./spec_helper"
 
 describe SierraBatch do

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -69,7 +69,7 @@ describe SierraManager do
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
                 .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
-            
+
             @test_manager.send(:_fetch_record_batch)
         end
 
@@ -151,7 +151,7 @@ describe SierraManager do
 
             @test_manager.stubs(:_update_processing_counts).with({ :success => 100, :error => 0 }).once
             @test_manager.state.stubs(:set_current_state).with('start_time', 100).once
-            
+
             @test_manager.send(:_process_batch, [])
 
             expect(@test_manager.processing).to eq(true)
@@ -185,13 +185,13 @@ describe SierraManager do
       it 'should send batch to kinesis and set state for max size if batch matches max size' do
           mock_batch = mock()
           mock_batch.stubs(:encode_and_send_to_kinesis).once
-          mock_batch.stubs(:size).returns(50).once
-          mock_batch.stubs(:process_statuses).returns({ :success => 50, :error => 0 }).once
+          mock_batch.stubs(:size).returns(100).once
+          mock_batch.stubs(:process_statuses).returns({ :success => 100, :error => 0 }).once
 
           SierraBatch.stubs(:new).returns(mock_batch)
 
-          @test_manager.stubs(:_update_processing_counts).with({ :success => 50, :error => 0 }).once
-          @test_manager.state.stubs(:set_current_state).with('start_time', 50).once
+          @test_manager.stubs(:_update_processing_counts).with({ :success => 100, :error => 0 }).once
+          @test_manager.state.stubs(:set_current_state).with('start_time', 100).once
 
           @test_manager.send(:_process_batch, [])
 

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -68,8 +68,8 @@ describe SierraManager do
 
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,]']])
-
+                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
+            
             @test_manager.send(:_fetch_record_batch)
         end
 
@@ -144,14 +144,14 @@ describe SierraManager do
         it 'should send batch to kinesis and set state for max size if batch matches max size' do
             mock_batch = mock()
             mock_batch.stubs(:encode_and_send_to_kinesis).once
-            mock_batch.stubs(:size).returns(50).once
-            mock_batch.stubs(:process_statuses).returns({ :success => 50, :error => 0 }).once
+            mock_batch.stubs(:size).returns(100).once
+            mock_batch.stubs(:process_statuses).returns({ :success => 100, :error => 0 }).once
 
             SierraBatch.stubs(:new).returns(mock_batch)
 
-            @test_manager.stubs(:_update_processing_counts).with({ :success => 50, :error => 0 }).once
-            @test_manager.state.stubs(:set_current_state).with('start_time', 50).once
-
+            @test_manager.stubs(:_update_processing_counts).with({ :success => 100, :error => 0 }).once
+            @test_manager.state.stubs(:set_current_state).with('start_time', 100).once
+            
             @test_manager.send(:_process_batch, [])
 
             expect(@test_manager.processing).to eq(true)

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -55,7 +55,7 @@ describe SierraManager do
     describe '#_fetch_record_batch' do
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]']])
+                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -68,7 +68,7 @@ describe SierraManager do
 
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
+                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end

--- a/spec/sierra_record_spec.rb
+++ b/spec/sierra_record_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../lib/sierra_record'
+require_relative '../lib/sierra_batch'
 require_relative './spec_helper'
 
 describe SierraBatch::SierraRecord do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ ENV['RECORD_FIELDS'] = 'test_fields'
 ENV['SIERRA_VERSION'] = 'v0'
 ENV['RETRY_COUNT'] = '3'
 ENV['S3_KEY'] = 'SierraTest'
+ENV['REQUEST_BATCH_SIZE'] = '100'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
From [discussion here](https://github.com/NYPL/sierraUpdatePollerV2/pull/36#issuecomment-1139198075)

This is step one in the following plan to rectify the git workflow for this app:
1. Merge `qa` > `development` (this merge will have conflicts that will need to be negotiated by devs familiar with the changes)
2. Remove stale branches including `production`
3. set the default branch to `development`
4. Note the [correct git workflow](https://github.com/NYPL/engineering-general/blob/main/standards/git-workflow.md#development-qa-main) in the README, e.g.:
```
## Contributing

This repo uses the [Development-QA-Main Git Workflow](https://github.com/NYPL/engineering-general/blob/master/standards/git-workflow.md#development-qa-main)
```

