### PR TITLE
Fix function name in terraform base to use deployment_name

### DIFF
--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -43,7 +43,7 @@ resource "aws_s3_object" "uploaded_zip" {
 # Create the lambda:
 resource "aws_lambda_function" "poller_lambda" {
   description                    = "A service for polling the Sierra API for updates from the Bibs endpoint"
-  function_name                  = "Sierra${var.record_type}UpdatePoller-${var.environment}"
+  function_name                  = "Sierra${var.deployment_name}UpdatePoller-${var.environment}"
   handler                        = "app.handle_event"
   memory_size                    = 128
   role                           = "arn:aws:iam::946183545209:role/lambda-full-access"


### PR DESCRIPTION
The variable `record_type` doesn't exist anymore, which is causing deployments to fail. Changed to use `deployment_name`, which exists and is being set in the other files.