### PR TITLE
Trying to fix qa deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_QA
     script:
     - rm -rf vendor
-    - bundle config set deployment 'true'; bundle config; bundle install --without test
+    - rake run_bundler
     - terraform -chdir=provisioning/qa/bib_update init -input=false
     - echo "Deploying Bib Update to qa"
     - terraform -chdir=provisioning/qa/bib_update apply -auto-approve -input=false

--- a/rakefile
+++ b/rakefile
@@ -13,7 +13,7 @@ end
 
 desc "Run bundler for local development and deployment"
 task :run_bundler do
-  sh %( bundle config unset deployment; bundle install; bundle config set deployment 'true'; bundle install )
+  sh %( bundle config unset deployment; bundle install; bundle config set deployment 'true'; bundle config set path 'vendor/bundle'; bundle install )
 end
 
 desc "Update lambda layers, environment_variables, vpc, and events"


### PR DESCRIPTION
.. by returning to calling `rake run_bundler` and modifying that task to
include explicitly calling `bundle config set path 'vendor/bundle'
because it seems that's not the default when config 'deployment' is
'true'?