### PR TITLE
Add debug logging of record ids received

### DIFF
--- a/config/bib-delete-production.env
+++ b/config/bib-delete-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/config/bib-production.env
+++ b/config/bib-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/config/holding-production.env
+++ b/config/holding-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/config/item-delete-production.env
+++ b/config/item-delete-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/config/item-production.env
+++ b/config/item-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/lib/sierra_batch.rb
+++ b/lib/sierra_batch.rb
@@ -26,7 +26,9 @@ class SierraBatch
         next
       end
     end
-    #Make sure that records are not unprocessed if total amount is not 
+
+    $logger.debug("Record ids", { ids: @records.map {|record| record['id'] } })
+    #Make sure that records are not unprocessed if total amount is not
     #divisible by $kinesis_client.batch_size. Any failed records are
     #saved in an instance variable on $kinesis_client
     $kinesis_client.push_records


### PR DESCRIPTION
- In `debug` logging, include ids of received records so we can tell what the app is processing
- Downgrade production to `info` level logging to keep the logs from getting too large.