### PR TITLE
fix update type in item delete env

### DIFF
--- a/config/item-delete-qa.env
+++ b/config/item-delete-qa.env
@@ -13,4 +13,4 @@ RECORD_FIELDS=default,fixedFields,varFields
 SCHEMA_TYPE=ItemPostRequest
 S3_KEY=ItemDelete
 KINESIS_STREAM=ItemPostRequest-qa
-UPDATE_TYPE=qa
+UPDATE_TYPE=delete


### PR DESCRIPTION
after this is merged/deployed, the s3 object for this poller needs to be reset to catch up on missed deletions. Note that deleted date timestamp should only have date, not time. 