### PR TITLE
Basic threading to improve throughput

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,25 +29,25 @@ jobs:
     - echo "Deploying Bib Update to qa"
     - terraform -chdir=provisioning/qa/bib_update apply -auto-approve -input=false
     #Bib delete
-    # - terraform -chdir=provisioning/qa/bib_delete init -input=false
-    # - echo "Deploying Bib Delete to qa"
-    # - terraform -chdir=provisioning/qa/bib_delete apply -auto-approve -input=false
+    - terraform -chdir=provisioning/qa/bib_delete init -input=false
+    - echo "Deploying Bib Delete to qa"
+    - terraform -chdir=provisioning/qa/bib_delete apply -auto-approve -input=false
     #Item Update
     - terraform -chdir=provisioning/qa/item_update init -input=false
     - echo "Deploying Item Update to qa"
     - terraform -chdir=provisioning/qa/item_update apply -auto-approve -input=false
     #Item Delete
-    # - terraform -chdir=provisioning/qa/item_delete init -input=false
-    # - echo "Deploying Item Delete to qa"
-    # - terraform -chdir=provisioning/qa/item_delete apply -auto-approve -input=false
+    - terraform -chdir=provisioning/qa/item_delete init -input=false
+    - echo "Deploying Item Delete to qa"
+    - terraform -chdir=provisioning/qa/item_delete apply -auto-approve -input=false
     #Holding Delete
-    # - terraform -chdir=provisioning/qa/holding_delete init -input=false
-    # - echo "Deploying Holding Delete to qa"
-    # - terraform -chdir=provisioning/qa/holding_delete apply -auto-approve -input=false
+    - terraform -chdir=provisioning/qa/holding_delete init -input=false
+    - echo "Deploying Holding Delete to qa"
+    - terraform -chdir=provisioning/qa/holding_delete apply -auto-approve -input=false
     #Holding Update
-    # - terraform -chdir=provisioning/qa/holding_update init -input=false
-    # - echo "Deploying Holding Update to qa"
-    # - terraform -chdir=provisioning/qa/holding_update apply -auto-approve -input=false
+    - terraform -chdir=provisioning/qa/holding_update init -input=false
+    - echo "Deploying Holding Update to qa"
+    - terraform -chdir=provisioning/qa/holding_update apply -auto-approve -input=false
     
   - stage: deploy production
     if: type IN (push) and branch = main

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,25 +29,25 @@ jobs:
     - echo "Deploying Bib Update to qa"
     - terraform -chdir=provisioning/qa/bib_update apply -auto-approve -input=false
     #Bib delete
-    - terraform -chdir=provisioning/qa/bib_delete init -input=false
-    - echo "Deploying Bib Delete to qa"
-    - terraform -chdir=provisioning/qa/bib_delete apply -auto-approve -input=false
+    # - terraform -chdir=provisioning/qa/bib_delete init -input=false
+    # - echo "Deploying Bib Delete to qa"
+    # - terraform -chdir=provisioning/qa/bib_delete apply -auto-approve -input=false
     #Item Update
     - terraform -chdir=provisioning/qa/item_update init -input=false
     - echo "Deploying Item Update to qa"
     - terraform -chdir=provisioning/qa/item_update apply -auto-approve -input=false
     #Item Delete
-    - terraform -chdir=provisioning/qa/item_delete init -input=false
-    - echo "Deploying Item Delete to qa"
-    - terraform -chdir=provisioning/qa/item_delete apply -auto-approve -input=false
+    # - terraform -chdir=provisioning/qa/item_delete init -input=false
+    # - echo "Deploying Item Delete to qa"
+    # - terraform -chdir=provisioning/qa/item_delete apply -auto-approve -input=false
     #Holding Delete
-    - terraform -chdir=provisioning/qa/holding_delete init -input=false
-    - echo "Deploying Holding Delete to qa"
-    - terraform -chdir=provisioning/qa/holding_delete apply -auto-approve -input=false
+    # - terraform -chdir=provisioning/qa/holding_delete init -input=false
+    # - echo "Deploying Holding Delete to qa"
+    # - terraform -chdir=provisioning/qa/holding_delete apply -auto-approve -input=false
     #Holding Update
-    - terraform -chdir=provisioning/qa/holding_update init -input=false
-    - echo "Deploying Holding Update to qa"
-    - terraform -chdir=provisioning/qa/holding_update apply -auto-approve -input=false
+    # - terraform -chdir=provisioning/qa/holding_update init -input=false
+    # - echo "Deploying Holding Update to qa"
+    # - terraform -chdir=provisioning/qa/holding_update apply -auto-approve -input=false
     
   - stage: deploy production
     if: type IN (push) and branch = main

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This function polls the Sierra API for updates to the Bib, Holding and Item tabl
 - SIERRA_OAUTH_URL: URI for the Sierra API authentication endpoint
 - SIERRA_OAUTH_ID: SENSITIVE, encoded ID for the Sierra API
 - SIERRA_OAUTH_SECRET: SENSITIVE, encoded secret key for the Sierra API
+- SKIP_UPDATING_STATE_FILE: Set to 'true' to skip uploading S3 state file (for local testing)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Testing is provided via `rspec` with `mocha` for stubbing/mocking. The test suit
 
 ## Contributing
 
-1. Cut a feature branch off of develomenth
+1. Cut a feature branch off of develoment
 2. Commit changes to your feature branch
 3. File a pull request against devlopment and assign a reviewer
 4. After the PR is accepted, merge into development

--- a/config/bib-qa.env
+++ b/config/bib-qa.env
@@ -13,4 +13,4 @@ RECORD_FIELDS=default,fixedFields,varFields,normTitle,normAuthor,orders,location
 SCHEMA_TYPE=BibPostRequest
 S3_KEY=BibPostRequest
 KINESIS_STREAM=BibPostRequest-qa
-REQUEST_BATCH_SIZE=100
+REQUEST_BATCH_SIZE=200

--- a/config/item-qa.env
+++ b/config/item-qa.env
@@ -13,3 +13,4 @@ RECORD_FIELDS=default,fixedFields,varFields
 SCHEMA_TYPE=ItemPostRequest
 S3_KEY=ItemPostRequest
 KINESIS_STREAM=ItemPostRequest-qa
+REQUEST_BATCH_SIZE=200

--- a/lib/sierra_batch.rb
+++ b/lib/sierra_batch.rb
@@ -4,11 +4,16 @@ class SierraBatch
   attr_reader :size, :offset, :records, :process_statuses
 
   def initialize(record_response)
+    @is_error = record_response.error?
     @size = record_response.body["total"]
     @offset = record_response.body["start"]
     @records = record_response.body["entries"]
     @process_statuses = { success: 0, error: 0 }
     @retry_count = (ENV["RETRY_COUNT"] || 3).to_i
+  end
+
+  def has_results?
+    !@is_error and @size > 0
   end
 
   def encode_and_send_to_kinesis

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -57,7 +57,7 @@ class SierraManager
   def send_results_to_kinesis
     unless @previous_results.nil?
       sierra_batch = SierraBatch.new(@previous_results)
-      sierra_batch.encode_and_send_to_kinesis
+      sierra_batch.encode_and_send_to_kinesis if sierra_batch.has_results?
       @previous_results = nil
 
       # Ensure we record the successes and errors for final validation:

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -130,14 +130,6 @@ class SierraManager
     # Extract relevant fields
     sierra_batch = SierraBatch.new(results)
 
-    # Removed for threading:
-    # Process records received
-    # sierra_batch.encode_and_send_to_kinesis
-
-    # Removed for threading:
-    # Update counts of total records processed
-    # _update_processing_counts sierra_batch.process_statuses
-
     # If we received fewer records than the maximum per batch this is the last batch
     # and we should set the state to start from this point and exit this invocation
     # else we should fetch and process the next batch

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -84,14 +84,11 @@ class SierraManager
   private
 
   # Fetches an individual record batch from Sierra
-  def _fetch_record_batch()
+  def _fetch_record_batch
     # Set up the GET request params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-                 [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
-            ["limit", @@request_batch_size]]
-    # param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-    #                [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
-    #                ["limit", @@request_batch_size]]
+                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
+                   ["limit", @@request_batch_size]]
 
     # Make query against Sierra API
     _query_sierra_api(param_array)

--- a/lib/state_manager.rb
+++ b/lib/state_manager.rb
@@ -62,12 +62,17 @@ class StateManager
     # Send object to S3.
     # If this fails the function errors and records are retried from the previous position
     begin
-      resp = @s3.put_object({
-        body: json_body,
-        bucket: ENV["BUCKET_NAME"],
-        key: "#{ENV['S3_KEY'].downcase}_poller_status.json",
-        acl: "public-read"
-      })
+      key = "#{ENV['S3_KEY'].downcase}_poller_status.json"
+      if ENV['SKIP_UPDATING_STATE_FILE'] == 'true'
+        $logger.info "Skipping updating updating #{key} because SKIP_UPDATING_STATE_FILE is enabled"
+      else
+        @s3.put_object({
+          body: json_body,
+          bucket: ENV["BUCKET_NAME"],
+          key: key,
+          acl: "public-read"
+        })
+      end
     rescue Exception => e
       $logger.error "Unable to store current state record in S3", { status: e.message }
       raise S3Error, "Failed to store most recent state record in S3"

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -12,16 +12,16 @@ Globals:
         LOG_LEVEL: debug
         S3_AWS_REGION: us-east-1
         NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com
-        PLATFORM_API_BASE_URL: https://dev-platform.nypl.org/api/v0.1/
-        BUCKET_NAME: sierra-poller-state-dev
+        PLATFORM_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1/
+        BUCKET_NAME: sierra-poller-state-qa
         SIERRA_API_BASE_URL: https://nypl-sierra-test.nypl.org:443/iii/sierra-api
         SIERRA_VERSION: v6
-        SIERRA_OAUTH_URL: https://nypl-sierra-test.nypl.org:443/iii/sierra-api/v3/token
-        SIERRA_OAUTH_ID: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQEPfTm0ZNPHAtRD1am3KPF8AAAAejB4BgkqhkiG9w0BBwagazBpAgEAMGQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMCSeDlLbDCkrUw5HgAgEQgDe3aLUovzs4zQKOR/+UQXEOWF98UvjAvPijVSi2WlVme+6gvCDAj/Eicp26/VsAbxc2OhdMazUZ
-        SIERRA_OAUTH_SECRET: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQGkTFrDp4UWdX4YCT2TX8iyAAAAcjBwBgkqhkiG9w0BBwagYzBhAgEAMFwGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMT5TuObnrfHCIbSk8AgEQgC8k9u2afElzRHRs+pPxjPsRGjPIrWQBD9VUssj3rE1IlRz4kF3FM8jc/GAyFKFsMA==
+        SIERRA_OAUTH_URL: https://nypl-sierra-test.nypl.org:443/iii/sierra-api/v6/token
+        SIERRA_OAUTH_ID: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAHoweAYJKoZIhvcNAQcGoGswaQIBADBkBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDJGDDlDYRAgm6Kq1CAIBEIA37Kuya0YgwuI3MPf83rCxeV75tN6Nh4pPGOIt5YInT+kdD89xTO3D/6B9OlK6T3+MWtymsJ+/Kg==
+        SIERRA_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGowaAYJKoZIhvcNAQcGoFswWQIBADBUBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDKmT3cEELMoZ2huyrwIBEIAnibbT57jJuV6ah2iATkcglCYHhQze8aQ291egun6IOpv6NTAMJ4Hv
         BATCH_SIZE: 50
         RETRY_COUNT: 3
-
+        RACK_ENV: development
 Resources:
   SierraHoldingsUpdatePoller:
     Type: AWS::Serverless::Function
@@ -33,3 +33,27 @@ Resources:
           RECORD_FIELDS: id,bibIds,bibIdLinks,itemIds,itemIdLinks,inheritLocation,allocationRule,accountingUnit,labelCode,serialCode1,serialCode2,serialCode3,serialCode4,claimOnDate,receivingLocationCode,vendorCode,updateCount,pieceCount,eCheckInCode,mediaTypeCode,updatedDate,createdDate,deletedDate,deleted,suppressed,fixedFields,varFields
           SCHEMA_TYPE: SierraHolding
           KINESIS_STREAM: SierraHoldingParser-dev
+  SierraItemUpdatePoller:
+    Type: AWS::Serverless::Function
+    Properties:
+      Environment:
+        Variables:
+          KINESIS_STREAM: ItemPostRequest-qa
+          RECORD_FIELDS: default,fixedFields,varFields
+          RECORD_TYPE: items
+          REQUEST_BATCH_SIZE: 200
+          S3_KEY: ItemPostRequest
+          SCHEMA_TYPE: ItemPostRequest
+          SKIP_UPDATING_STATE_FILE: true
+  SierraBibUpdatePoller:
+    Type: AWS::Serverless::Function
+    Properties:
+      Environment:
+        Variables:
+          KINESIS_STREAM: BibPostRequest-qa
+          RECORD_FIELDS: default,fixedFields,varFields,normTitle,normAuthor,orders,locations
+          RECORD_TYPE: bibs
+          REQUEST_BATCH_SIZE: 200
+          S3_KEY: BibPostRequest
+          SCHEMA_TYPE: BibPostRequest
+          SKIP_UPDATING_STATE_FILE: true

--- a/spec/sierra_batch_spec.rb
+++ b/spec/sierra_batch_spec.rb
@@ -9,6 +9,8 @@ describe SierraBatch do
       "start" => 0,
       "entries" => (1..50).to_a.map { |x| { "id" => x } }.compact
     })
+    mock_response.stubs(:error?).returns(false)
+
     @test_batch = SierraBatch.new(mock_response)
     $kinesis_client = mock
     @failed_records = mock

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -20,7 +20,7 @@ describe SierraManager do
     }
 
     describe '#fetch_updated_records' do
-        it 'should process batches until process is set to false' do
+        xit 'should process batches until process is set to false' do
             DateTime.stubs(:now).returns('current_time')
 
             @test_manager.stubs(:_fetch_record_batch).returns('result1', 'result2')
@@ -53,7 +53,7 @@ describe SierraManager do
     end
 
     describe '#_fetch_record_batch' do
-        it 'should query the Sierra API with the current querry settings' do
+        xit 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
                 .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
 
@@ -66,7 +66,7 @@ describe SierraManager do
           ENV['UPDATE_TYPE'] = 'delete'
         end
 
-        it 'should query the Sierra API with the current querry settings' do
+        xit 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
                 .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,]'], ['limit', 100]])
 
@@ -125,7 +125,7 @@ describe SierraManager do
           @test_manager.instance_variable_set(:@current_time, current_time)
         end
 
-        it 'should send batch to kinesis and reset state if batch is less than max size' do
+        xit 'should send batch to kinesis and reset state if batch is less than max size' do
             mock_batch = mock()
             mock_batch.stubs(:encode_and_send_to_kinesis).once
             mock_batch.stubs(:size).returns(49).once
@@ -141,7 +141,7 @@ describe SierraManager do
             expect(@test_manager.processing).to eq(false)
         end
 
-        it 'should send batch to kinesis and set state for max size if batch matches max size' do
+        xit 'should send batch to kinesis and set state for max size if batch matches max size' do
             mock_batch = mock()
             mock_batch.stubs(:encode_and_send_to_kinesis).once
             mock_batch.stubs(:size).returns(100).once
@@ -166,7 +166,7 @@ describe SierraManager do
         ENV['UPDATE_TYPE'] = 'delete'
       end
 
-      it 'should send batch to kinesis and reset state if batch is less than max size' do
+      xit 'should send batch to kinesis and reset state if batch is less than max size' do
           mock_batch = mock()
           mock_batch.stubs(:encode_and_send_to_kinesis).once
           mock_batch.stubs(:size).returns(49).once
@@ -182,7 +182,7 @@ describe SierraManager do
           expect(@test_manager.processing).to eq(false)
       end
 
-      it 'should send batch to kinesis and set state for max size if batch matches max size' do
+      xit 'should send batch to kinesis and set state for max size if batch matches max size' do
           mock_batch = mock()
           mock_batch.stubs(:encode_and_send_to_kinesis).once
           mock_batch.stubs(:size).returns(100).once

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -9,6 +9,10 @@ describe SierraManager do
         sierra_stub = mock()
         NYPLRubyUtil::SierraApiClient.stubs(:new).returns(sierra_stub)
 
+        $logger = mock()
+        $logger.stubs(:info)
+        $logger.stubs(:debug)
+        $logger.stubs(:error)
         $kms_client = mock()
         $kms_client.stubs(:decrypt).returns(0, 0)
 
@@ -17,11 +21,15 @@ describe SierraManager do
 
     after(:each) {
         NYPLRubyUtil::SierraApiClient.unstub(:new)
+        $logger.unstub()
     }
 
     describe '#fetch_updated_records' do
-        xit 'should process batches until process is set to false' do
+        it 'should process batches until process is set to false' do
             DateTime.stubs(:now).returns('current_time')
+
+            # Skip kinesis processing for this test:
+            @test_manager.stubs(:send_results_to_kinesis)
 
             @test_manager.stubs(:_fetch_record_batch).returns('result1', 'result2')
             @test_manager.stubs(:_parse_result_batch).with() { |value|
@@ -35,6 +43,32 @@ describe SierraManager do
             @test_manager.fetch_updated_records
             expect(@test_manager.processing).to eq(false)
             expect(@test_manager.current_time).to eq('current_time')
+        end
+
+        it 'should send previously fetched batch to kinesis on each run' do
+            DateTime.stubs(:now).returns('current_time')
+
+            # Expect SierraBatch.encode_and_send_to_kinesis called twice
+            mock_batch = mock()
+            mock_batch.stubs(:encode_and_send_to_kinesis).twice
+            mock_batch.stubs(:has_results?).twice.returns(true)
+            mock_batch.stubs(:process_statuses).returns({ success: 0, error: 0 })
+
+            # Expect two SierraBatch instances created around the two results:
+            SierraBatch.stubs(:new).with('result1').returns(mock_batch)
+            SierraBatch.stubs(:new).with('result2').returns(mock_batch)
+
+            @test_manager.stubs(:_fetch_record_batch).returns('result1', 'result2')
+            @test_manager.stubs(:_parse_result_batch).with() do |value|
+                if value == 'result2'
+                    @test_manager.processing = false
+                end
+                true
+            end
+
+            expect(@test_manager.processing).to eq(true)
+            @test_manager.fetch_updated_records
+            expect(@test_manager.processing).to eq(false)
         end
     end
 
@@ -53,7 +87,7 @@ describe SierraManager do
     end
 
     describe '#_fetch_record_batch' do
-        xit 'should query the Sierra API with the current querry settings' do
+        it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
                 .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
 
@@ -66,7 +100,7 @@ describe SierraManager do
           ENV['UPDATE_TYPE'] = 'delete'
         end
 
-        xit 'should query the Sierra API with the current querry settings' do
+        it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
                 .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,]'], ['limit', 100]])
 
@@ -118,22 +152,18 @@ describe SierraManager do
     end
 
     describe '#_process_batch' do
-
         current_time = DateTime.now
 
         before(:each) do
           @test_manager.instance_variable_set(:@current_time, current_time)
         end
 
-        xit 'should send batch to kinesis and reset state if batch is less than max size' do
+        it 'should reset state if batch is less than max size' do
             mock_batch = mock()
-            mock_batch.stubs(:encode_and_send_to_kinesis).once
             mock_batch.stubs(:size).returns(49).once
-            mock_batch.stubs(:process_statuses).returns({ :success => 49, :error => 0 }).once
 
             SierraBatch.stubs(:new).returns(mock_batch)
 
-            @test_manager.stubs(:_update_processing_counts).with({ :success => 49, :error => 0 }).once
             @test_manager.state.stubs(:set_current_state).with(current_time.to_s, 0).once
 
             @test_manager.send(:_process_batch, [])
@@ -141,15 +171,12 @@ describe SierraManager do
             expect(@test_manager.processing).to eq(false)
         end
 
-        xit 'should send batch to kinesis and set state for max size if batch matches max size' do
+        it 'should set state for max size if batch matches max size' do
             mock_batch = mock()
-            mock_batch.stubs(:encode_and_send_to_kinesis).once
             mock_batch.stubs(:size).returns(100).once
-            mock_batch.stubs(:process_statuses).returns({ :success => 100, :error => 0 }).once
 
             SierraBatch.stubs(:new).returns(mock_batch)
 
-            @test_manager.stubs(:_update_processing_counts).with({ :success => 100, :error => 0 }).once
             @test_manager.state.stubs(:set_current_state).with('start_time', 100).once
 
             @test_manager.send(:_process_batch, [])
@@ -166,15 +193,12 @@ describe SierraManager do
         ENV['UPDATE_TYPE'] = 'delete'
       end
 
-      xit 'should send batch to kinesis and reset state if batch is less than max size' do
+      it 'should reset state if batch is less than max size' do
           mock_batch = mock()
-          mock_batch.stubs(:encode_and_send_to_kinesis).once
           mock_batch.stubs(:size).returns(49).once
-          mock_batch.stubs(:process_statuses).returns({ :success => 49, :error => 0 }).once
 
           SierraBatch.stubs(:new).returns(mock_batch)
 
-          @test_manager.stubs(:_update_processing_counts).with({ :success => 49, :error => 0 }).once
           @test_manager.state.stubs(:set_current_state).with(current_time.to_date.to_s, 0).once
 
           @test_manager.send(:_process_batch, [])
@@ -182,15 +206,12 @@ describe SierraManager do
           expect(@test_manager.processing).to eq(false)
       end
 
-      xit 'should send batch to kinesis and set state for max size if batch matches max size' do
+      it 'should set state for max size if batch matches max size' do
           mock_batch = mock()
-          mock_batch.stubs(:encode_and_send_to_kinesis).once
           mock_batch.stubs(:size).returns(100).once
-          mock_batch.stubs(:process_statuses).returns({ :success => 100, :error => 0 }).once
 
           SierraBatch.stubs(:new).returns(mock_batch)
 
-          @test_manager.stubs(:_update_processing_counts).with({ :success => 100, :error => 0 }).once
           @test_manager.state.stubs(:set_current_state).with('start_time', 100).once
 
           @test_manager.send(:_process_batch, [])

--- a/spec/state_manager_spec.rb
+++ b/spec/state_manager_spec.rb
@@ -6,10 +6,14 @@ describe StateManager do
         @s3_stub = mock()
         Aws::S3::Client.stubs(:new).returns(@s3_stub)
         @test_manager = StateManager.new
+        $logger = mock()
+        $logger.stubs(:debug)
+        $logger.stubs(:error)
     }
 
     after(:each) {
         Aws::S3::Client.unstub(:new)
+        $logger.unstub()
     }
 
     describe '#fetch_current_state' do


### PR DESCRIPTION
Add threading to allow app to run the two most expensive operations
concurrently:
 - Waiting for a Sierra API response
 - Avro encoding Sierra data (from the most recent Sierra response)

The concurrency over a 3 resultset batch works like this:
 - Thread1 fetches first set of Sierra results (R1) while Thread2 does nothing
 - Thread1 fetches next set of Sierra results (R2) while Thread2 encodes R1
 - Thread1 fetches R3 (and notes processing is complete) while Thread2 encodes R2
 - App encodes R3 and exits