### PR TITLE
NOREF - Fix race condition (and manual jobs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
 - unzip terraform_"$TF_VERSION"_linux_amd64.zip
 - sudo mv terraform /usr/local/bin/
 - rm terraform_"$TF_VERSION"_linux_amd64.zip
-- gem update --system
 - gem install bundler
 - gem install aws-sdk-lambda
 - gem install aws-sdk-cloudwatchevents

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ before_install:
 - unzip terraform_"$TF_VERSION"_linux_amd64.zip
 - sudo mv terraform /usr/local/bin/
 - rm terraform_"$TF_VERSION"_linux_amd64.zip
-- gem install bundler
-- gem install aws-sdk-lambda
-- gem install aws-sdk-cloudwatchevents
+- gem install bundler -v 2.4.22
 install:
 - rake run_bundler
 jobs:

--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,6 @@ def handle_event(event:, context:)
   end
 
   # Load records given current starting position in state
-  $logger.info "Fetching information from Sierra API"
   sierra = SierraManager.new(state)
   sierra.fetch_updated_records
   sierra.validate_processing

--- a/config/bib-production.env
+++ b/config/bib-production.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=info
+LOG_LEVEL=debug
 S3_AWS_REGION=us-east-1
 NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com
 PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/

--- a/lib/manual_job_state_manager.rb
+++ b/lib/manual_job_state_manager.rb
@@ -1,6 +1,7 @@
 class ManualJobStateManager
     def initialize(event)
         @event = event
+        @offset = @event['start_offset']
     end
 
     def start_time
@@ -12,8 +13,10 @@ class ManualJobStateManager
     end
 
     def start_offset
-        @event['start_offset']
+      @offset
     end
 
-    def set_current_state(execution_time, execution_offset); end
+    def set_current_state(execution_time, execution_offset)
+      @offset = execution_offset
+    end
 end

--- a/lib/sierra_batch.rb
+++ b/lib/sierra_batch.rb
@@ -18,7 +18,7 @@ class SierraBatch
 
   def encode_and_send_to_kinesis
     start_time = Time.now
-    $logger.info("Batch write to kinesis starting at #{start_time}")
+    $logger.debug("Batch write to kinesis starting at #{start_time}")
     #Send individual records to $kinesis_client and log encoding errors
     @records.each do |record|
       sierra_record = SierraRecord.new(record)
@@ -45,7 +45,7 @@ class SierraBatch
       ids = $kinesis_client.failed_records.map{ |record| record[:id] }.join(", ")
       $logger.warn("#{$kinesis_client.failed_records.length} records failed to enter the kinesis stream, with ids: #{ids}")
     end
-    $logger.info("#{@records.length} records sent to kinesis in #{Time.now - start_time} seconds")
+    $logger.debug("#{@records.length} records sent to kinesis in #{Time.now - start_time} seconds")
   end
 
   class SierraRecord

--- a/lib/sierra_batch.rb
+++ b/lib/sierra_batch.rb
@@ -56,7 +56,9 @@ class SierraBatch
     end
 
     def encode_and_send_to_kinesis
-      $kinesis_client << @record
+      if ENV["DRYRUN"].nil?
+        $kinesis_client << @record
+      end
     end
   end
 end

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -30,7 +30,8 @@ class SierraManager
   def fetch_updated_records
     # This sets the end fetch time for the current invocation and will be the start_time for the next invocation
     @current_time = DateTime.now
-    $logger.info "Beginning Sierra fetch: #{@state.start_time} - #{end_time}"
+    @job_start_time = @state.start_time
+    $logger.info "Beginning Sierra fetch: #{@job_start_time} - #{end_time}"
 
     # Fetch batches of records until no more remain to process
     while @processing
@@ -69,7 +70,7 @@ class SierraManager
       # Ensure we record the successes and errors for final validation:
       _update_processing_counts sierra_batch.process_statuses
 
-      $logger.info "Collected and sent #{@records_processed[:success]} records so far for #{@state.start_time} - #{end_time}"
+      $logger.info "Collected and sent #{@records_processed[:success]} records so far for #{@job_start_time} - #{end_time}"
     end
   end
 
@@ -124,13 +125,13 @@ class SierraManager
   def _query_sierra_api(param_array)
     # Encode request params
     param_str = URI.encode_www_form(param_array)
-    start_time = Time.now
+    _start_time = Time.now
     $logger.debug("Querying Sierra API with params #{param_str}")
 
     # Execute request and handle errors
     begin
       result = @sierra_client.get("/#{ENV['SIERRA_VERSION']}/#{ENV['RECORD_TYPE']}?#{param_str}")
-      $logger.info("Received Sierra response in #{Time.now - start_time} seconds")
+      $logger.info("Received Sierra response in #{Time.now - _start_time} seconds")
     rescue Exception => e
       $logger.error("Failed to query Sierra API", { status: e.message })
       raise SierraError, "Received error from Sierra API. Review logs"

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -91,6 +91,8 @@ class SierraManager
 
   private
 
+  # Returns the relevant end_time for this job (either the manual end_time or
+  # the "current_time" recorded at the start)
   def end_time
     @state.is_a?(ManualJobStateManager) ? @state.end_time : current_time
   end
@@ -99,7 +101,6 @@ class SierraManager
   def _fetch_record_batch
     # Set up the GET request params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-                   # [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
                    [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{end_time}]"],
                    ["limit", @@request_batch_size]]
 

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -91,10 +91,11 @@ class SierraManager
 
   # Fetches an individual record batch from Sierra
   def _fetch_record_batch
+    end_time = @state.is_a?(ManualJobStateManager) ? @state.end_time : current_time
     # Set up the GET request params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
                    # [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
-                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{@state.end_time}]"],
+                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{end_time}]"],
                    ["limit", @@request_batch_size]]
 
     # Make query against Sierra API

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -36,7 +36,7 @@ class SierraManager
     while @processing
       threads = []
 
-      # Thread 1: Encode previously fetcedFetch next set of results:
+      # Thread 1: Encode previously fetched results:
       threads << Thread.new { send_results_to_kinesis }
       # Thread 2: Fetch next set of results:
       threads << Thread.new do

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -57,6 +57,7 @@ class SierraManager
   def send_results_to_kinesis
     unless @previous_results.nil?
       sierra_batch = SierraBatch.new(@previous_results)
+      puts "Send to kinesis? #{ENV["DRYRUN"].nil?}"
       sierra_batch.encode_and_send_to_kinesis if sierra_batch.has_results?
       @previous_results = nil
 
@@ -87,7 +88,8 @@ class SierraManager
   def _fetch_record_batch
     # Set up the GET request params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
-                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
+                   # [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],
+                   [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{@state.end_time}]"],
                    ["limit", @@request_batch_size]]
 
     # Make query against Sierra API
@@ -133,10 +135,12 @@ class SierraManager
     # If we received fewer records than the maximum per batch this is the last batch
     # and we should set the state to start from this point and exit this invocation
     # else we should fetch and process the next batch
+    puts " #{sierra_batch.size} >= #{@@request_batch_size} so "
     if sierra_batch.size < @@request_batch_size
       @state.set_current_state(current_time, 0)
       @processing = false
     else
+      puts "@state.set_current_state(#{@state.start_time}, #{@state.start_offset} + #{@@request_batch_size})"
       @state.set_current_state(@state.start_time, @state.start_offset + @@request_batch_size)
     end
   end

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -30,7 +30,7 @@ class SierraManager
   def fetch_updated_records
     # This sets the end fetch time for the current invocation and will be the start_time for the next invocation
     @current_time = DateTime.now
-    $logger.info "Setting fetch (end) time to #{current_time}"
+    $logger.info "Beginning Sierra fetch: #{@state.start_time} - #{end_time}"
 
     # Fetch batches of records until no more remain to process
     while @processing
@@ -68,6 +68,8 @@ class SierraManager
 
       # Ensure we record the successes and errors for final validation:
       _update_processing_counts sierra_batch.process_statuses
+
+      $logger.info "Collected and sent #{@records_processed[:success]} records so far for #{@state.start_time} - #{end_time}"
     end
   end
 
@@ -89,9 +91,12 @@ class SierraManager
 
   private
 
+  def end_time
+    @state.is_a?(ManualJobStateManager) ? @state.end_time : current_time
+  end
+
   # Fetches an individual record batch from Sierra
   def _fetch_record_batch
-    end_time = @state.is_a?(ManualJobStateManager) ? @state.end_time : current_time
     # Set up the GET request params
     param_array = [["fields", ENV["RECORD_FIELDS"]], ["offset", @state.start_offset],
                    # [ENV['UPDATE_TYPE'] == 'delete' ? 'deletedDate' : 'updatedDate', "[#{@state.start_time},#{current_time}]"],

--- a/lib/sierra_manager.rb
+++ b/lib/sierra_manager.rb
@@ -21,8 +21,8 @@ class SierraManager
       client_id: $kms_client.decrypt(ENV["SIERRA_OAUTH_ID"]),
       client_secret: $kms_client.decrypt(ENV["SIERRA_OAUTH_SECRET"])
     )
-    # This will hold the most recently retrieved Sierra response object:
-    @previous_results = nil
+    # This will hold the most recently retrieved Sierra response objects:
+    @previous_results = []
   end
 
   # Fetch records in batches from the Sierra API
@@ -36,14 +36,19 @@ class SierraManager
     while @processing
       threads = []
 
-      # Thread 1: Fetch next set of results:
-      threads << Thread.new do
-        # Save Sierra response object - to process during the next fetch:
-        @previous_results = _fetch_record_batch()
-        _parse_result_batch(@previous_results)
-      end
-      # Thread 2: Encode previously fetcedFetch next set of results:
+      # Thread 1: Encode previously fetcedFetch next set of results:
       threads << Thread.new { send_results_to_kinesis }
+      # Thread 2: Fetch next set of results:
+      threads << Thread.new do
+        # Fetch next set of records from Sierra:
+        batch = _fetch_record_batch()
+
+        # Update state file based on what was received:
+        _parse_result_batch(batch)
+
+        # Save response object to process during the next fetch:
+        @previous_results << batch
+      end
 
       threads.each { |thr| thr.join }
     end
@@ -55,11 +60,11 @@ class SierraManager
   # If we have any previously retrieved Sierra response object waiting to be
   # sent to Kinesis, send it:
   def send_results_to_kinesis
-    unless @previous_results.nil?
-      sierra_batch = SierraBatch.new(@previous_results)
-      puts "Send to kinesis? #{ENV["DRYRUN"].nil?}"
+    # @previous_results will be empty on the first run (before the first set of
+    # results have been received):
+    unless @previous_results.empty?
+      sierra_batch = SierraBatch.new(@previous_results.shift)
       sierra_batch.encode_and_send_to_kinesis if sierra_batch.has_results?
-      @previous_results = nil
 
       # Ensure we record the successes and errors for final validation:
       _update_processing_counts sierra_batch.process_statuses
@@ -135,12 +140,10 @@ class SierraManager
     # If we received fewer records than the maximum per batch this is the last batch
     # and we should set the state to start from this point and exit this invocation
     # else we should fetch and process the next batch
-    puts " #{sierra_batch.size} >= #{@@request_batch_size} so "
     if sierra_batch.size < @@request_batch_size
       @state.set_current_state(current_time, 0)
       @processing = false
     else
-      puts "@state.set_current_state(#{@state.start_time}, #{@state.start_offset} + #{@@request_batch_size})"
       @state.set_current_state(@state.start_time, @state.start_offset + @@request_batch_size)
     end
   end

--- a/lib/state_manager.rb
+++ b/lib/state_manager.rb
@@ -50,7 +50,7 @@ class StateManager
 
   # Set new state values for execution time and offset. Invoked upon succesful parsing of a batch
   def set_current_state(execution_time, execution_offset)
-    $logger.debug "Setting state from last fetch execution EXECUTION_TIME: #{execution_time}, EXECUTION_OFFSET: #{execution_offset}"
+    $logger.debug "Updating S3 state file EXECUTION_TIME: #{execution_time}, EXECUTION_OFFSET: #{execution_offset}"
 
     # Create a JSON object
     json_body = JSON.dump({

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -5,7 +5,6 @@ describe SierraManager do
     before(:each) {
         mock_state = mock()
         mock_state.stubs(:start_time).returns('start_time')
-        mock_state.stubs(:end_time).returns('end_time')
         mock_state.stubs(:start_offset).returns(0)
         sierra_stub = mock()
         NYPLRubyUtil::SierraApiClient.stubs(:new).returns(sierra_stub)
@@ -120,8 +119,9 @@ describe SierraManager do
 
     describe '#_fetch_record_batch' do
         it 'should query the Sierra API with the current querry settings' do
+            @test_manager.stubs(:current_time).returns('fake-time')
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,end_time]'], ['limit', 100]])
+                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,fake-time]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end
@@ -133,8 +133,9 @@ describe SierraManager do
         end
 
         it 'should query the Sierra API with the current querry settings' do
+            @test_manager.stubs(:current_time).returns('fake-time')
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,end_time]'], ['limit', 100]])
+                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,fake-time]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end

--- a/spec/sierra_manager_spec.rb
+++ b/spec/sierra_manager_spec.rb
@@ -5,6 +5,7 @@ describe SierraManager do
     before(:each) {
         mock_state = mock()
         mock_state.stubs(:start_time).returns('start_time')
+        mock_state.stubs(:end_time).returns('end_time')
         mock_state.stubs(:start_offset).returns(0)
         sierra_stub = mock()
         NYPLRubyUtil::SierraApiClient.stubs(:new).returns(sierra_stub)
@@ -70,6 +71,37 @@ describe SierraManager do
             @test_manager.fetch_updated_records
             expect(@test_manager.processing).to eq(false)
         end
+
+        it 'should send previously fetched batch to kinesis even if kinesis is slow' do
+            DateTime.stubs(:now).returns('current_time')
+
+            # Expect SierraBatch.encode_and_send_to_kinesis called twice
+            mock_batch = mock()
+            mock_batch.stubs(:encode_and_send_to_kinesis).twice.with do
+              sleep 1
+            end
+            mock_batch.stubs(:has_results?).twice.returns(true)
+            mock_batch.stubs(:process_statuses).returns({ success: 1, error: 0 })
+
+            # Expect two SierraBatch instances created around the two results:
+            SierraBatch.stubs(:new).with('result1').returns(mock_batch)
+            SierraBatch.stubs(:new).with('result2').returns(mock_batch)
+
+            @test_manager.stubs(:_fetch_record_batch).returns('result1', 'result2')
+
+            @test_manager.stubs(:_parse_result_batch).with() do |value|
+                if value == 'result2'
+                    @test_manager.processing = false
+                end
+                true
+            end
+
+            expect(@test_manager.processing).to eq(true)
+            @test_manager.fetch_updated_records
+            expect(@test_manager.processing).to eq(false)
+
+            expect(@test_manager.records_processed).to eq({ success: 2, error: 0 })
+        end
     end
 
     describe '#validate_processing' do
@@ -89,7 +121,7 @@ describe SierraManager do
     describe '#_fetch_record_batch' do
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,]'], ['limit', 100]])
+                .with([['fields', 'test_fields'], ['offset', 0], ['updatedDate', '[start_time,end_time]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end
@@ -102,7 +134,7 @@ describe SierraManager do
 
         it 'should query the Sierra API with the current querry settings' do
             @test_manager.stubs(:_query_sierra_api)
-                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,]'], ['limit', 100]])
+                .with([['fields', 'test_fields'], ['offset', 0], ['deletedDate', '[start_time,end_time]'], ['limit', 100]])
 
             @test_manager.send(:_fetch_record_batch)
         end


### PR DESCRIPTION
Fix race condition that may drop records when kinesis write time exceeds Sierra fetch time:

When more than `request_batch_size` (e.g. 100) results are received, the poller must fetch a second set of records. Writing the first set of records to kinesis occurs in parallel to fetching that second set of records. If Sierra takes N time to return the second set of records, but it takes N + 1 time to write the first set of records to Kinesis, the app (previously) nullified the second result set (held in @previous_results), making it impossible for the app to subsequently send the second result set through kinesis. Essentially, the app assumed that fetching records from Sierra will always be slower than writing records to Kinesis, which is not always true. This has caused the last page of records to sometimes be dropped when there are multiple pages (and kinesis writes are slow).

The fix is to recast our @previous_records (holding the most recently fetched records) as an array of resultsets, so that it can grow to hold multiple (although I suspect it will only ever have max 1 as written) buffered resultsets if Kinesis is slow to write. In the scenario above, instead of nullifying @previous_results after writing the records to Kinesis, the kinesis-writing code shifts the resultset off of @previous_results right before beginning the kinesis-write, allowing the Sierra-retreiving code to safely push additional resultsets onto @previous_results without risk that they'll be erroneously nullified.

Also: This fixes handling of "manual jobs", which previously didn't handle jobs targeting more than `request_batch_size` due to not supporting updating `offset`